### PR TITLE
教材のCSVインポート機能を実装

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_220_418_064_906) do
+ActiveRecord::Schema.define(version: 2022_04_18_064906) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,4 +39,5 @@ ActiveRecord::Schema.define(version: 20_220_418_064_906) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
+
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+require "import_csv"
+
 # texts, movies テーブルを再生成（関連付くテーブルを含む）
 %w[texts movies].each do |table_name|
   ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
@@ -10,3 +12,6 @@ User.find_or_create_by!(email: email) do |user|
   user.password = password
   puts "ユーザーの初期データインポートに成功しました。"
 end
+
+ImportCsv.import_text_data("db/csv_data/text_data.csv")
+puts "text_dataのインポートに成功しました。"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,4 +14,5 @@ User.find_or_create_by!(email: email) do |user|
 end
 
 ImportCsv.import_text_data("db/csv_data/text_data.csv")
-puts "text_dataのインポートに成功しました。"
+ImportCsv.import_movie_data("db/csv_data/movie_data.csv")
+puts "CSVファイルのインポートに成功しました。"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,8 @@
+# texts, movies テーブルを再生成（関連付くテーブルを含む）
+%w[texts movies].each do |table_name|
+  ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
+end
+
 email = "test@example.com"
 password = "password"
 

--- a/lib/import_csv.rb
+++ b/lib/import_csv.rb
@@ -6,4 +6,10 @@ class ImportCsv
       Text.create!(row.to_h)
     end
   end
+
+  def self.import_movie_data(path)
+    CSV.foreach(path, headers: true) do |row|
+      Movie.create!(row.to_h)
+    end
+  end
 end

--- a/lib/import_csv.rb
+++ b/lib/import_csv.rb
@@ -1,0 +1,9 @@
+require "csv"
+
+class ImportCsv
+  def self.import_text_data(path)
+    CSV.foreach(path, headers: true) do |row|
+      Text.create!(row.to_h)
+    end
+  end
+end


### PR DESCRIPTION
close #11 

## 実装内容

**「タスク5 バリデーションを追加 #7 」完了後に実装**

- `db/seeds.rb` の3行目に以下を追加

```
# texts, movies テーブルを再生成（関連付くテーブルを含む）
%w[texts movies].each do |table_name|
  ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
end
```

- `lib`配下に`import_csv.rb`を作成
    - テキスト教材のCSV（`db/csv_data/text_data.csv`）と動画教材のCSV（`db/csv_data/movie_data.csv`）を読み込み　texts テーブル、movies テーブルにデータを投入する処理を追加


- `db/seeds.rb` で`import_csv.rb`内で定義したメソッドを呼び出す処理を記述

## 確認内容

以下を実施して、テーブルにデータが投入されているか確認。

```bash
rails db:seed
rails c

Text.all
Movie.all
```

## 参考資料

- [【やんばるエキスパート教材】CSVインポート](https://www.yanbaru-code.com/texts/217)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## 【備考】

使用しているVSCodeの設定により`db/schema.rb`内の記述方法が修正されたため、「Files changed」に加えられています。
内容自体に変更はありません。