### PR TITLE
フラッシュの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,26 +3,34 @@
  *= require_self
  */
 
- @import "bootstrap/scss/bootstrap";
- .base-container {
-    margin: 0 auto;
-    padding: 1rem;
-  }
-  
-  /* max-width */ 
-  
-  .mw-sm {
-    max-width: 576px;
-  }
-  
-  .mw-md {
-    max-width: 768px;
-  }
-  
-  .mw-lg {
-    max-width: 992px;
-  }
-  
-  .mw-xl {
-    max-width: 1200px;
-  }
+@import 'bootstrap/scss/bootstrap';
+.base-container {
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+/* max-width */
+
+.mw-sm {
+  max-width: 576px;
+}
+
+.mw-md {
+  max-width: 768px;
+}
+
+.mw-lg {
+  max-width: 992px;
+}
+
+.mw-xl {
+  max-width: 1200px;
+}
+
+// フラッシュ
+.alert-notice {
+  @extend .alert-success;
+}
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |flash_type, msg| %>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
    </header>
    <hr>
     <main>
+      <%= render "layouts/flash" %>
       <%# max_width メソッドは application_helper.rb に記載 %>
      <div class="base-container <%= max_width %>">
       <%= yield %>


### PR DESCRIPTION
close #14 

## 実装内容
**タスク #10【8. Bootstrapの導入】完了後に実装**

- フラッシュの表示機能
  - 部分テンプレート `app/views/layouts/_flash.html.erb` を作成
  - `main`タグの開始タグすぐ下で部分テンプレートの読み込み

- フラッシュの背景色を設定
  - `notice` は  `alert-success`, `alert` は `alert-danger` を使用
  - `application.scss`にてBootstrapで使用できるように`extend`を実装

## 確認内容

- ログイン時・ログアウト時にフラッシュが表示されることを確認 

## 参考資料

- [【公式】Bootstrap（Alerts）](https://getbootstrap.jp/docs/4.5/components/alerts/)
- [【やんばるエキスパート教材】メッセージ投稿アプリ その3）](https://www.yanbaru-code.com/texts/271)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
