### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,0 +1,6 @@
+.movie-header {
+  height: 200px;
+}
+.movie-body {
+  height: 190px;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.order(id: :asc)
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).order(id: :asc)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,3 +1,5 @@
 class MoviesController < ApplicationController
-  def index; end
+  def index
+    @movies = Movie.order(id: :asc)
+  end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,0 +1,12 @@
+module MoviesHelper
+  def embed_youtube(url)
+    tag.iframe(
+      width: 360,
+      height: 200,
+      src: url,
+      frameborder: 0,
+      allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
+      allowfullscreen: true
+    )
+  end
+end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,7 +1,7 @@
 module MoviesHelper
   def embed_youtube(url)
     tag.iframe(
-      width: 360,
+      width: "100%",
       height: 200,
       src: url,
       frameborder: 0,

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,4 +1,6 @@
 class Movie < ApplicationRecord
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,11 +1,13 @@
-<div class="col mb-3">
-  <div class="card border-dark">
-    <%# ===== `embed_youtube`メソッドはmoviesヘルパーで定義 ===== %>
-    <div class="card-header p-0 movie-header"><%= embed_youtube(movie.url) %></div>
+<% if Movie::RAILS_GENRE_LIST.include?(movie.genre) %>
+  <div class="col mb-3">
+    <div class="card border-dark">
+      <%# ===== `embed_youtube`メソッドはmoviesヘルパーで定義 ===== %>
+      <div class="card-header p-0 movie-header"><%= embed_youtube(movie.url) %></div>
 
-    <div class="card-body movie-body">
-      <button type="button" class="btn btn-secondary btn-block mb-4">読破済みにする</button>
-      <p><%= movie.title %></p>
+      <div class="card-body movie-body">
+        <button type="button" class="btn btn-secondary btn-block mb-4">読破済みにする</button>
+        <p>Lv.<%= movie_counter + 1 %>：<%= movie.title %></p>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -4,7 +4,7 @@
     <div class="card-header p-0 movie-header"><%= embed_youtube(movie.url) %></div>
 
     <div class="card-body movie-body">
-      <button type="button" class="btn btn-secondary btn-block mb-4">読破済みにする</button>
+      <button type="button" class="btn btn-secondary btn-block mb-4">視聴済みにする</button>
       <p>Lv.<%= movie_counter + 1 %>：<%= movie.title %></p>
     </div>
   </div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,5 +1,11 @@
-<div class="col">
-  <%# ===== `embed_youtube`メソッドはmoviesヘルパーで定義 ===== %>
-  <%= embed_youtube(movie.url) %>
-  <p><%= movie.title %></p>
+<div class="col mb-3">
+  <div class="card border-dark">
+    <%# ===== `embed_youtube`メソッドはmoviesヘルパーで定義 ===== %>
+    <div class="card-header p-0 movie-header"><%= embed_youtube(movie.url) %></div>
+
+    <div class="card-body movie-body">
+      <button type="button" class="btn btn-secondary btn-block mb-4">読破済みにする</button>
+      <p><%= movie.title %></p>
+    </div>
+  </div>
 </div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,13 +1,11 @@
-<% if Movie::RAILS_GENRE_LIST.include?(movie.genre) %>
-  <div class="col mb-3">
-    <div class="card border-dark">
-      <%# ===== `embed_youtube`メソッドはmoviesヘルパーで定義 ===== %>
-      <div class="card-header p-0 movie-header"><%= embed_youtube(movie.url) %></div>
+<div class="col mb-3">
+  <div class="card border-dark">
+    <%# ===== `embed_youtube`メソッドはmoviesヘルパーで定義 ===== %>
+    <div class="card-header p-0 movie-header"><%= embed_youtube(movie.url) %></div>
 
-      <div class="card-body movie-body">
-        <button type="button" class="btn btn-secondary btn-block mb-4">読破済みにする</button>
-        <p>Lv.<%= movie_counter + 1 %>：<%= movie.title %></p>
-      </div>
+    <div class="card-body movie-body">
+      <button type="button" class="btn btn-secondary btn-block mb-4">読破済みにする</button>
+      <p>Lv.<%= movie_counter + 1 %>：<%= movie.title %></p>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <iframe width="360" height="200" src="<%= movie.url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <p><%= movie.title %></p>
+</div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,4 +1,5 @@
-<div>
-  <iframe width="360" height="200" src="<%= movie.url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div class="col">
+  <%# ===== `embed_youtube`メソッドはmoviesヘルパーで定義 ===== %>
+  <%= embed_youtube(movie.url) %>
   <p><%= movie.title %></p>
 </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,8 +1,8 @@
-<div class="text-center mt-3">
+<div class="text-center my-4">
   <h1>Ruby/Rails 動画</h1>
 </div>
 
-<div class="container">
+<div class="container-fluid">
   <div class="row row-cols-3">
     <%= render @movies %>
   </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,0 +1,7 @@
+<div class="text-center mt-3">
+  <h1>Ruby/Rails 動画</h1>
+</div>
+
+<div>
+  <%= render @movies %>
+</div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div class="container-fluid">
-  <div class="row row-cols-3">
+  <div class="row row-cols-lg-3 row-cols-md-2 row-cols-1">
     <%= render @movies %>
   </div>
 </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -2,6 +2,8 @@
   <h1>Ruby/Rails 動画</h1>
 </div>
 
-<div>
-  <%= render @movies %>
+<div class="container">
+  <div class="row row-cols-3">
+    <%= render @movies %>
+  </div>
 </div>


### PR DESCRIPTION
close #17 

## 実装内容

**「タスク8,9,10」完了後に実施**

- `app/models/movie.rb` に次を定義

```rb
  RAILS_GENRE_LIST = %w[basic git ruby rails]
```

- Rails動画教材の一覧ページを作成
  - 表示するジャンルは `Movie::RAILS_GENRE_LIST` に制限
  - Bootstrapの `Cards` や `Grid System` を使用
  - `$ touch app/views/movies/_movie.html.erb`を実施して部分テンプレートを作成
  - 埋め込み動画を表示するヘルパーメソッドを`movies_helper.rb`を作成してその中に定義
  - 各動画に`<%= movie_counter + 1 %>`を使ってレベル表示
  - カードの下側部分に`app/assets/stylesheets/movies.scss` を作成して`height: 190px;` を指定
  - 「読破済みボタン」を設置
  - レスポンシブ対応

## 確認内容

- 画像のようにレスポンシブ対応ができているかどうかを確認
- カードの高さが一定になっているか確認
- PHPの動画教材が表示されていないことを確認

## 参考資料（必要があれば）

- [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)
- [【公式】Embeds](https://getbootstrap.com/docs/4.5/utilities/embed/)
- [【やんばるエキスパート教材】YouTube動画の投稿](https://www.yanbaru-code.com/texts/349)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット

**ヘッダー部分のスタイルが崩れていました。**
今回タスク範囲外のため、ご報告のみさせていただきます。
<img width="188" alt="team_yanbaru" src="https://user-images.githubusercontent.com/96477692/168547720-331a4f92-bd46-4a11-bd45-d3a68797b7cc.png">
