### PR TITLE
動画教材ページのジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).order(id: :asc)
+    @movies = Movie.switch_movies_by_genres(params)
   end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,4 +1,7 @@
 module MoviesHelper
+  PHP_MOVIES_TITLE = "PHP動画教材".freeze
+  RAILS_MOVIES_TITLE = "Ruby/Rails 動画".freeze
+
   def embed_youtube(url)
     tag.iframe(
       width: "100%",
@@ -8,5 +11,10 @@ module MoviesHelper
       allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
       allowfullscreen: true
     )
+  end
+
+  # ===== 動画教材のタイトルを切り替える処理 =====
+  def switch_movies_title
+    params[:genre] == "php" ? PHP_MOVIES_TITLE : RAILS_MOVIES_TITLE
   end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,5 +1,5 @@
 module MoviesHelper
-  PHP_MOVIES_TITLE = "PHP動画教材".freeze
+  PHP_MOVIES_TITLE = "PHP 動画".freeze
   RAILS_MOVIES_TITLE = "Ruby/Rails 動画".freeze
 
   def embed_youtube(url)

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -15,4 +15,13 @@ class Movie < ApplicationRecord
     rails: 4,
     php: 5
   }
+
+  # ===== Rails動画教材かPHP動画教材のどちらを表示するかの処理 =====
+  def self.switch_movies_by_genres(params)
+    if params[:genre] == "php"
+      Movie.where(genre: "php").order(id: :asc)
+    else
+      Movie.where(genre: Movie::RAILS_GENRE_LIST).order(id: :asc)
+    end
+  end
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,5 +1,5 @@
 <div class="text-center my-4">
-  <h1>Ruby/Rails 動画</h1>
+  <h1><%= switch_movies_title %></h1>  <%# ===== `movies_helper:17`参照 ===== %>
 </div>
 
 <div class="container-fluid">


### PR DESCRIPTION
close #20 

## 実装内容

**「タスク15」完了後に実施**

- PHP動画教材ページで「PHPの動画教材のみ」が表示されるように修正
  - `params[:genre] == php`を使用して、条件分岐
  - `movie.rb`にクラスメソッドを定義

- 「Ruby/Rails動画教材ページ」のタイトルを「Ruby/Rails 動画」，「PHP動画教材ページ」のタイトルは「PHP 動画」に修正
  - `app/helpers/application_helper.rb` にメソッドを定義
  - 各タイトルは定数を定義して使用

## 確認内容

- 「Ruby/Rails動画教材」に「PHP動画」が含まれていないことを確認
- 「PHP動画教材」に「PHP動画」のみが表示されていることを確認
- クエリパラメータ `?genre=php` を `php` 以外に変更してアクセスした際は「Ruby/Rails動画教材」が表示されることを確認

## 参考

- [4. パラメータ - Railsガイド](https://railsguides.jp/action_controller_overview.html#%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
