### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,12 +14,11 @@ gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"
 gem "rails", "~> 6.1.1"
 gem "rails-i18n", "~> 6.0"
+gem "redcarpet"
+gem "rouge"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
-gem "redcarpet"
-gem "rouge"
-
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,9 @@ gem "rails-i18n", "~> 6.0"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
+gem "redcarpet"
+gem "rouge"
+
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,11 +214,13 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     regexp_parser (2.2.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
+    rouge (3.28.0)
     rubocop (1.25.0)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -308,6 +310,8 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
   rails-i18n (~> 6.0)
+  redcarpet
+  rouge
   rubocop-performance
   rubocop-rails
   sass-rails (>= 6)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,7 +7,7 @@
  @import "bootstrap/scss/bootstrap";
  
  a:hover {
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
  .base-container {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,10 @@
 
  @import "bootstrap/scss/bootstrap";
  
+ a:hover {
+  text-decoration: none;
+}
+
  .base-container {
     margin: 0 auto;
     padding: 1rem;

--- a/app/assets/stylesheets/markdown.scss
+++ b/app/assets/stylesheets/markdown.scss
@@ -1,0 +1,46 @@
+@import "bootstrap/scss/bootstrap";
+
+.markdown {
+  table {
+    @extend .table;
+    display: block;
+    overflow-x: scroll;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    border: initial;
+
+    thead {
+      background-color: #EEFFFF;
+    }
+  }
+
+  h1 {
+    font-size: 1.75rem;
+    text-align: left;
+  }
+
+  pre {
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
+    background-color: #f6ffff;
+    padding: 0.5rem;
+    margin: 1rem 0;
+    border: 2px dashed #d6dddd;
+
+    code {
+      table.rouge-table {
+        margin: 0;
+
+        td.rouge-code {
+          padding: 0;
+          vertical-align: top;
+
+          pre {
+            padding: 5px 10px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/rouge.scss.erb
+++ b/app/assets/stylesheets/rouge.scss.erb
@@ -1,0 +1,1 @@
+<%= Rouge::Themes::Github.render(scope: '.highlight') %>

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -3,5 +3,7 @@ class TextsController < ApplicationController
     @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
   end
 
-  def show; end
+  def show
+  end
+
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -4,6 +4,7 @@ class TextsController < ApplicationController
   end
 
   def show
+    @text = Text.find(params[:id])
   end
 
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -6,5 +6,4 @@ class TextsController < ApplicationController
   def show
     @text = Text.find(params[:id])
   end
-
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,30 @@
+module MarkdownHelper
+    def markdown(text)
+      renderer = Redcarpet::Render::HTML.new(render_options)
+      Redcarpet::Markdown.new(renderer, extensions).render(text).html_safe
+    end
+  
+    private
+  
+    def render_options
+      {
+        filter_html: false, # htmlを無効化
+        hard_wrap: true, # 改行を br 要素に変換
+        link_attributes: { target: "_blank", rel: "noopener" } # リンクの設定
+      }
+    end
+  
+    def extensions
+      {
+        autolink: true, # http https ftpで始まる文字列を自動リンク
+        fenced_code_blocks: true, # コードブロックを解析
+        no_intra_emphasis: true, # 単語内の強調を解析しない
+        tables: true, # 	テーブルを解析
+        space_after_headers: true, # ヘッダーの先頭のハッシュとハッシュ名の間にスペースを要求
+        hard_wrap: true, # 改行を br 要素に変換
+        xhtml: true, # xhtml のタグを出力する(Render::XHTMLでは常に有効)
+        lax_html_blocks: true # 複数行のコードの前後に空行が不要
+        # strikethrough: true, # 取り消し線(~)を解析する
+      }
+    end
+  end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,30 +1,30 @@
 module MarkdownHelper
-    def markdown(text)
-      renderer = Redcarpet::Render::HTML.new(render_options)
-      Redcarpet::Markdown.new(renderer, extensions).render(text).html_safe
-    end
-  
-    private
-  
-    def render_options
-      {
-        filter_html: false, # htmlを無効化
-        hard_wrap: true, # 改行を br 要素に変換
-        link_attributes: { target: "_blank", rel: "noopener" } # リンクの設定
-      }
-    end
-  
-    def extensions
-      {
-        autolink: true, # http https ftpで始まる文字列を自動リンク
-        fenced_code_blocks: true, # コードブロックを解析
-        no_intra_emphasis: true, # 単語内の強調を解析しない
-        tables: true, # 	テーブルを解析
-        space_after_headers: true, # ヘッダーの先頭のハッシュとハッシュ名の間にスペースを要求
-        hard_wrap: true, # 改行を br 要素に変換
-        xhtml: true, # xhtml のタグを出力する(Render::XHTMLでは常に有効)
-        lax_html_blocks: true # 複数行のコードの前後に空行が不要
-        # strikethrough: true, # 取り消し線(~)を解析する
-      }
-    end
+  def markdown(text)
+    renderer = Redcarpet::Render::HTML.new(render_options)
+    Redcarpet::Markdown.new(renderer, extensions).render(text).html_safe
   end
+
+  private
+
+  def render_options
+    {
+      filter_html: false, # htmlを無効化
+      hard_wrap: true, # 改行を br 要素に変換
+      link_attributes: { target: "_blank", rel: "noopener" } # リンクの設定
+    }
+  end
+
+  def extensions
+    {
+      autolink: true, # http https ftpで始まる文字列を自動リンク
+      fenced_code_blocks: true, # コードブロックを解析
+      no_intra_emphasis: true, # 単語内の強調を解析しない
+      tables: true, # 	テーブルを解析
+      space_after_headers: true, # ヘッダーの先頭のハッシュとハッシュ名の間にスペースを要求
+      hard_wrap: true, # 改行を br 要素に変換
+      xhtml: true, # xhtml のタグを出力する(Render::XHTMLでは常に有効)
+      lax_html_blocks: true # 複数行のコードの前後に空行が不要
+      # strikethrough: true, # 取り消し線(~)を解析する
+    }
+  end
+end

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,4 +1,5 @@
 <div class="col-12 col-md-6 col-lg-4 ">  
+  <%= link_to  text_path(text.id) do %>
     <div class="card content-card border-dark mb-3 ">
         <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg">
         <div class="card-body text-dark ">
@@ -11,4 +12,5 @@
           </p>
        </div>
     </div>
+  <% end %>  
 </div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,1 +1,8 @@
-<%= @text.content %>
+<h1 class = "text-center my-4" ><%= @text.title %></h1>
+<%
+    str = @text.content
+%>
+<div class="markdown">
+  <%= markdown(str) %>
+</div>
+

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,1 @@
+<%= @text.content %>


### PR DESCRIPTION
close #19

## 実装内容
 - aタグの下線が入らないように`app/assets/stylesheets/application.scss`に次を追加
```
a:hover {
  text-decoration: none!important ;
}
``` 
 - `link_to`のブロックを使用し一覧ページから詳細ページに移動できるようにする
 - マークダウン形式を変換する`redcarpet`, シンタックスハイライトを適用する `rouge`をインストール
 ```
gem "redcarpet"
gem "rouge"
```
 - `app/helpers/markdown_helper.rb` を作成し，次を設定
```
module MarkdownHelper
  def markdown(text)
    renderer = Redcarpet::Render::HTML.new(render_options)
    Redcarpet::Markdown.new(renderer, extensions).render(text).html_safe
  end

  private

  def render_options
    {
      filter_html: false, # htmlを無効化
      hard_wrap: true, # 改行を br 要素に変換
      link_attributes: { target: "_blank", rel: "noopener" } # リンクの設定
    }
  end

  def extensions
    {
      autolink: true, # http https ftpで始まる文字列を自動リンク
      fenced_code_blocks: true, # コードブロックを解析
      no_intra_emphasis: true, # 単語内の強調を解析しない
      tables: true, # 	テーブルを解析
      space_after_headers: true, # ヘッダーの先頭のハッシュとハッシュ名の間にスペースを要求
      hard_wrap: true, # 改行を br 要素に変換
      xhtml: true, # xhtml のタグを出力する(Render::XHTMLでは常に有効)
      lax_html_blocks: true # 複数行のコードの前後に空行が不要
      # strikethrough: true, # 取り消し線(~)を解析する
    }
  end
end
```
 - `app/assets/stylesheets/markdown.scss` を作成し，マークダウン専用のスタイルを追加
```
@import "bootstrap/scss/bootstrap";

.markdown {
  table {
    @extend .table;
    display: block;
    overflow-x: scroll;
    white-space: nowrap;
    -webkit-overflow-scrolling: touch;
    border: initial;

    thead {
      background-color: #EEFFFF;
    }
  }

  h1 {
    font-size: 1.75rem;
    text-align: left;
  }

  pre {
    overflow: auto;
    word-wrap: normal;
    white-space: pre;
    background-color: #f6ffff;
    padding: 0.5rem;
    margin: 1rem 0;
    border: 2px dashed #d6dddd;

    code {
      table.rouge-table {
        margin: 0;

        td.rouge-code {
          padding: 0;
          vertical-align: top;

          pre {
            padding: 5px 10px;
          }
        }
      }
    }
  }
}
```
 - markdown クラスを付けたタグで囲み、詳細ページを実装
   - 「タイトル(title)」と「内容(content)」を表示
   - 「内容」はマークダウンを変換した表示ができるようにする
## 確認内容

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
- [ ] `rubocop -a` を実行
