### PR TITLE
動画教材の視聴済み機能

### DIFF
--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,2 +1,11 @@
 class WatchProgressesController < ApplicationController
+  def create
+    current_user.watch_progresses.create!(movie_id: params[:movie_id])
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    current_user.watch_progresses.destroy!(movie_id: params[:movie_id])
+    redirect_back(fallback_location: root_path)
+  end
 end

--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,11 +1,17 @@
 class WatchProgressesController < ApplicationController
+  before_action :set_movie, only: %i[create destroy]
+
   def create
-    current_user.watch_progresses.create!(movie_id: params[:movie_id])
-    redirect_back(fallback_location: root_path)
+    current_user.watch_progresses.create!(movie_id: @movie.id)
   end
 
   def destroy
-    current_user.watch_progresses.destroy!(movie_id: params[:movie_id])
-    redirect_back(fallback_location: root_path)
+    current_user.watch_progresses.find_by(movie_id: @movie.id).destroy!
+  end
+
+  private
+
+  def set_movie
+    @movie = Movie.find(params[:movie_id])
   end
 end

--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,0 +1,2 @@
+class WatchProgressesController < ApplicationController
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -21,13 +21,13 @@ class Movie < ApplicationRecord
   # ===== Rails動画教材かPHP動画教材のどちらを表示するかの処理 =====
   def self.switch_movies_by_genres(params)
     if params[:genre] == "php"
-      Movie.where(genre: "php").order(id: :asc)
+      Movie.includes(:watch_progresses).where(genre: "php").order(id: :asc)
     else
-      Movie.where(genre: RAILS_GENRE_LIST).order(id: :asc)
+      Movie.includes(:watch_progresses).where(genre: RAILS_GENRE_LIST).order(id: :asc)
     end
   end
 
   def watched_or_not?(user)
-    watch_progresses.exists?(user_id: user.id)
+    watch_progresses.any? { |watch_progress| watch_progress.user_id == user.id }
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -26,4 +26,8 @@ class Movie < ApplicationRecord
       Movie.where(genre: RAILS_GENRE_LIST).order(id: :asc)
     end
   end
+
+  def watched_or_not?(user)
+    watch_progresses.exists?(user_id: user.id)
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,6 +1,8 @@
 class Movie < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
+  has_many :watch_progresses, dependent: :destroy
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :watch_progresses, dependent: :destroy
+
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
 

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,4 +1,9 @@
 class WatchProgress < ApplicationRecord
   belongs_to :user
   belongs_to :movie
+
+  validates :user_id, uniqueness: {
+    scope: :movie_id,
+    message: "は同じ動画教材を2回以上視聴済みにはできません"
+  }
 end

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,0 +1,4 @@
+class WatchProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :movie
+end

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -4,7 +4,15 @@
     <div class="card-header p-0 movie-header"><%= embed_youtube(movie.url) %></div>
 
     <div class="card-body movie-body">
-      <button type="button" class="btn btn-secondary btn-block mb-4">視聴済みにする</button>
+      <% if movie.watched_or_not?(current_user) %>
+        <%= link_to movie_watch_progresses_path(movie), method: :destroy do %>
+          <button type="button" class="btn btn-primary btn-block mb-4">視聴済みを解除</button>
+        <% end %>
+      <% else %>
+        <%= link_to movie_watch_progresses_path(movie), method: :post do %>
+          <button type="button" class="btn btn-secondary btn-block mb-4">視聴済みにする</button>
+        <% end %>
+      <% end %>
       <p>Lv.<%= movie_counter + @movies.offset_value + 1 %>：<%= movie.title %></p>
     </div>
   </div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -4,13 +4,15 @@
     <div class="card-header p-0 movie-header"><%= embed_youtube(movie.url) %></div>
 
     <div class="card-body movie-body">
-      <% if movie.watched_or_not?(current_user) %>
-        <%# =====「視聴済み」の状態 ===== %>
-        <%= render "movies/watch", movie: movie %>
-      <% else %>
-        <%# =====「視聴済みではない」状態 ===== %>
-        <%= render "movies/not_watch", movie: movie %>
-      <% end %>
+      <div id="movie-<%= movie.id %>">
+        <% if movie.watched_or_not?(current_user) %>
+          <%# =====「視聴済み」の状態 ===== %>
+          <%= render "movies/watch", movie: movie %>
+        <% else %>
+          <%# =====「視聴済みではない」状態 ===== %>
+          <%= render "movies/not_watch", movie: movie %>
+        <% end %>
+      </div>
 
       <p>Lv.<%= movie_counter + @movies.offset_value + 1 %>：<%= movie.title %></p>
     </div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -5,14 +5,13 @@
 
     <div class="card-body movie-body">
       <% if movie.watched_or_not?(current_user) %>
-        <%= link_to movie_watch_progresses_path(movie), method: :destroy do %>
-          <button type="button" class="btn btn-primary btn-block mb-4">視聴済みを解除</button>
-        <% end %>
+        <%# =====「視聴済み」の状態 ===== %>
+        <%= render "movies/watch", movie: movie %>
       <% else %>
-        <%= link_to movie_watch_progresses_path(movie), method: :post do %>
-          <button type="button" class="btn btn-secondary btn-block mb-4">視聴済みにする</button>
-        <% end %>
+        <%# =====「視聴済みではない」状態 ===== %>
+        <%= render "movies/not_watch", movie: movie %>
       <% end %>
+
       <p>Lv.<%= movie_counter + @movies.offset_value + 1 %>：<%= movie.title %></p>
     </div>
   </div>

--- a/app/views/movies/_not_watch.html.erb
+++ b/app/views/movies/_not_watch.html.erb
@@ -1,0 +1,3 @@
+<%= link_to movie_watch_progresses_path(movie), method: :post do %>
+  <button type="button" class="btn btn-secondary btn-block mb-4">視聴済みにする</button>
+<% end %>

--- a/app/views/movies/_not_watch.html.erb
+++ b/app/views/movies/_not_watch.html.erb
@@ -1,3 +1,3 @@
-<%= link_to movie_watch_progresses_path(movie), method: :post do %>
+<%= link_to movie_watch_progresses_path(movie), method: :post, remote: true do %>
   <button type="button" class="btn btn-secondary btn-block mb-4">視聴済みにする</button>
 <% end %>

--- a/app/views/movies/_watch.html.erb
+++ b/app/views/movies/_watch.html.erb
@@ -1,0 +1,3 @@
+<%= link_to movie_watch_progresses_path(movie), method: :destroy do %>
+  <button type="button" class="btn btn-primary btn-block mb-4">視聴済みを解除</button>
+<% end %>

--- a/app/views/movies/_watch.html.erb
+++ b/app/views/movies/_watch.html.erb
@@ -1,3 +1,3 @@
-<%= link_to movie_watch_progresses_path(movie), method: :destroy do %>
+<%= link_to movie_watch_progresses_path(movie), method: :delete, remote: true do %>
   <button type="button" class="btn btn-primary btn-block mb-4">視聴済みを解除</button>
 <% end %>

--- a/app/views/watch_progresses/create.js.erb
+++ b/app/views/watch_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("movie-<%= @movie.id %>").innerHTML = "<%= j render("movies/watch", movie: @movie) %>"

--- a/app/views/watch_progresses/destroy.js.erb
+++ b/app/views/watch_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("movie-<%= @movie.id %>").innerHTML = "<%= j render("movies/not_watch", movie: @movie) %>"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       text: 'テキスト教材'
       movie: '動画教材'
+      watch_progress: '視聴済み'
     attributes:
       text:
         genre: 'ジャンル'
@@ -12,6 +13,9 @@ ja:
         genre: 'ジャンル'
         title: 'タイトル'
         url: 'URL'
+      watch_progress:
+        user: 'ユーザ'
+        movie: '動画教材'
   attributes:
     id: ID
     namespace: 名前空間

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,8 @@ Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   resources :texts, only: %i[index show]
-  resources :movies, only: :index
+
+  resources :movies, only: :index do
+    resource :watch_progresses, only: %i[create destroy]
+  end
 end

--- a/db/migrate/20220606054736_create_watch_progresses.rb
+++ b/db/migrate/20220606054736_create_watch_progresses.rb
@@ -1,0 +1,11 @@
+class CreateWatchProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :watch_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :movie, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :watch_progresses, [:user_id, :movie_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_07_002331) do
+ActiveRecord::Schema.define(version: 2022_06_06_054736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,4 +66,16 @@ ActiveRecord::Schema.define(version: 2022_05_07_002331) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  create_table "watch_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "movie_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["movie_id"], name: "index_watch_progresses_on_movie_id"
+    t.index ["user_id", "movie_id"], name: "index_watch_progresses_on_user_id_and_movie_id", unique: true
+    t.index ["user_id"], name: "index_watch_progresses_on_user_id"
+  end
+
+  add_foreign_key "watch_progresses", "movies"
+  add_foreign_key "watch_progresses", "users"
 end


### PR DESCRIPTION
close #25 

## 実装内容

**「タスク15」完了後に実施**

- 視聴済み機能に使用する `WatchProgress` モデルを作成
  - 外部キー設定を行い，ユニーク制約を入れてからマイグレーション
  - バリデーションをモデルに追加
  - アソシエーションの設定
  - 日本語化
- `WatchProgressController`の作成
  - ルーティングの設定(`resources :movie`にネスト)
- 「視聴済み」アクションの非同期化
  -  `js.erb`で実装

## 確認内容

```zsh
rails c -s
# Railsコンソール起動後
user = User.first
movie, movie2 = Movie.limit(2)
WatchProgress.delete_all
user.watch_progresses.create!(movie_id: movie.id)
user.watch_progresses.create!(movie_id: movie2.id)
WatchProgress.count
#=> 2
movie.watch_progresses.create!(user_id: user.id)
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: Userは同じ動画教材を2回以上視聴済みにはできません
WatchProgress.create!
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: ユーザーを入力してください, 動画教材を入力してください
```

- 動画教材一覧ページの視聴済み機能が動作していることを確認

## 参考資料

- [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
- [ ] `rubocop -a` を実行