### PR TITLE
link_toの引数をURLからPathに変更

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,8 +11,8 @@
       <li class="nav-item active dropdown">
       <%= link_to "Ruby","#", class:"nav-link dropdown-toggle",id:"navbarDropdownMenuLink" , 'data-toggle': :dropdown, 'aria-haspopup': :true, 'aria-expanded': :false %>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <%= link_to "Ruby/Railsテキスト教材", "http://localhost:3000/texts", class: "dropdown-item" %>
-          <%= link_to "Ruby/Rails動画教材", "http://localhost:3000/movies", class: "dropdown-item" %>
+          <%= link_to "Ruby/Railsテキスト教材",texts_path, class: "dropdown-item" %>
+          <%= link_to "Ruby/Rails動画教材", movies_path, class: "dropdown-item" %>
         </div>
       </li>
     


### PR DESCRIPTION
close #26

## 実装内容
 - Herokuにプッシュした際に自動でマイグレーションを行う設定を追加
```
echo "release: bin/rails db:migrate" > Procfile
```
 - Heroku アプリを作成

## 確認内容

ローカル環境で実施した動作内容
 - ナビバー`Rails　テキスト教材　動画教材`をクリックし問題なく動作することを確認

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
